### PR TITLE
Define inline when using Microsoft's C compiler

### DIFF
--- a/caption/eia608.h
+++ b/caption/eia608.h
@@ -37,6 +37,12 @@ static const uint8_t eia608_parity_table[] = { EIA608_B1 (0), EIA608_B1 (64) };
 extern const char* eia608_mode_map[];
 extern const char* eia608_style_map[];
 
+#ifdef _MSC_VER
+#ifndef inline
+#define inline __inline
+#endif
+#endif
+
 /*! \brief
     \param
 */


### PR DESCRIPTION
By default, Microsoft's C compiler does not support the 'inline' keyword
(it does with C++, but not C).  Instead, it uses the __inline keyword,
so you must check to see if it's the Microsoft C compiler, and if so,
define inline as a macro for __inline.