### PR TITLE
Fix MSVC size conversion/cast compiler warnings

### DIFF
--- a/src/avc.c
+++ b/src/avc.c
@@ -572,7 +572,7 @@ void avcnalu_init (avcnalu_t* nalu)
 int avcnalu_parse_annexb (avcnalu_t* nalu, const uint8_t** data, size_t* size)
 {
     int scpos, sclen;
-    int new_size = nalu->size + (*size);
+    int new_size = (int) (nalu->size + (*size));
 
     if (new_size > MAX_NALU_SIZE) {
         (*size) = nalu->size = 0;
@@ -580,7 +580,7 @@ int avcnalu_parse_annexb (avcnalu_t* nalu, const uint8_t** data, size_t* size)
     }
 
     memcpy (&nalu->data[nalu->size], (*data), (*size));
-    scpos = avc_find_start_code_increnental (&nalu->data[0], new_size, nalu->size, &sclen);
+    scpos = avc_find_start_code_increnental (&nalu->data[0], new_size, (int) nalu->size, &sclen);
 
     if (0<=scpos) {
         (*data) += (scpos - nalu->size) + sclen;

--- a/src/eia608.c.re2c
+++ b/src/eia608.c.re2c
@@ -160,7 +160,7 @@ static int eia608_to_index (uint16_t cc_data, int* chan, int* c1, int* c2)
 int eia608_to_utf8 (uint16_t c, int* chan, char* str1,  char* str2)
 {
     int c1, c2;
-    size_t size = eia608_to_index (c,chan,&c1,&c2);
+    int size = (int) eia608_to_index (c,chan,&c1,&c2);
     strncpy (str1, utf8_from_index (c1),5);
     strncpy (str2, utf8_from_index (c2),5);
     return size;

--- a/src/srt.c
+++ b/src/srt.c
@@ -160,10 +160,10 @@ srt_t* srt_from_caption_frame (caption_frame_t* frame, srt_t* prev, srt_t** head
 
 static inline void _crack_time (double tt, int* hh, int* mm, int* ss, int* ms)
 {
-    (*ms) = (int64_t) (tt * 1000) % 1000;
-    (*ss) = (int64_t) (tt) % 60;
-    (*mm) = (int64_t) (tt / (60)) % 60;
-    (*hh) = (int64_t) (tt / (60*60));
+    (*ms) = (int) ((int64_t) (tt * 1000.0) % 1000);
+    (*ss) = (int) ((int64_t) (tt) % 60);
+    (*mm) = (int) ((int64_t) (tt / (60.0)) % 60);
+    (*hh) = (int) ((int64_t) (tt / (60.0*60.0)));
 }
 
 static void _dump (srt_t* head, char type)


### PR DESCRIPTION
At higher warning levels, Microsoft's C compiler will throw warnings
when implicitly casting 64bit data as 32bit due to possible data loss,
so explicitly cast to prevent those warnings.