### PR TITLE
Fix CMake Install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,7 @@ set(CAPTION_SOURCES
 
 set(CAPTION_HEADERS
   caption/utf8.h
-  caption/sei.h
   caption/scc.h
-  caption/avc.c
   caption/cea708.h
   caption/eia608.h
   caption/caption.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,40 +49,40 @@ endif()
 
 add_executable(flv2srt examples/flv2srt.c examples/flv.c)
 target_link_libraries(flv2srt caption)
-#install (FILES flv2srt DESTINATION bin)
+install(TARGETS flv2srt DESTINATION bin)
 
 add_executable(ts2srt examples/ts2srt.c examples/ts.c)
 target_link_libraries(ts2srt caption)
-#install (FILES ts2srt DESTINATION bin)
+install(TARGETS ts2srt DESTINATION bin)
 
 add_executable(flv+srt examples/flv+srt.c examples/flv.c)
 target_link_libraries(flv+srt caption)
-#install (FILES flv+srt DESTINATION bin)
+install(TARGETS flv+srt DESTINATION bin)
 
 add_executable(party examples/party.c examples/flv.c)
 target_link_libraries(party caption)
-#install (FILES party DESTINATION bin)
+install(TARGETS party DESTINATION bin)
 
 add_executable(srtdump examples/srtdump.c )
 target_link_libraries(srtdump caption)
-#install (FILES srtdump DESTINATION bin)
+install(TARGETS srtdump DESTINATION bin)
 
 add_executable(srt2vtt examples/srt2vtt.c)
 target_link_libraries(srt2vtt caption)
-#install (FILES srt2vtt DESTINATION bin)
+install(TARGETS srt2vtt DESTINATION bin)
 
 add_executable(scc2srt examples/scc2srt.c)
 target_link_libraries(scc2srt caption)
-#install (FILES scc2srt DESTINATION bin)
+install(TARGETS scc2srt DESTINATION bin)
 
 add_executable(rollup examples/rollup.c examples/flv.c)
 target_link_libraries(rollup caption)
-#install (FILES rollup DESTINATION bin)
+install(TARGETS rollup DESTINATION bin)
 
 #include_directories(/usr/local/include)
 #add_executable(rtmpspit examples/rtmpspit.c  examples/flv.c)
 #target_link_libraries(rtmpspit caption rtmp)
-#install (FILES rtmpspit DESTINATION bin)
+#install(TARGETS rtmpspit DESTINATION bin)
 
 # unit-tests
 #add_executable(eia608_test unit_tests/eia608_test.c )


### PR DESCRIPTION
In this PR:
* Removed header references sei.h (no longer in this project) and avc.c (mistakenly listed as a header file)
* Fixed install() scripts for executable targets

After the fixes:

```console
$ make install
[ 34%] Built target caption
[ 40%] Built target srt2vtt
[ 50%] Built target ts2srt
[ 56%] Built target srtdump
[ 65%] Built target party
[ 75%] Built target flv+srt
[ 84%] Built target flv2srt
[ 93%] Built target rollup
[100%] Built target scc2srt
Install the project...
-- Install configuration: "Release"
-- Installing: ${...path removed...}/bin/flv2srt
-- Installing: ${...path removed...}/bin/ts2srt
-- Installing: ${...path removed...}/bin/flv+srt
-- Installing: ${...path removed...}/bin/party
-- Installing: ${...path removed...}/bin/srtdump
-- Installing: ${...path removed...}/bin/srt2vtt
-- Installing: ${...path removed...}/bin/scc2srt
-- Installing: ${...path removed...}/bin/rollup
-- Installing: ${...path removed...}/lib/libcaption.a
-- Installing: ${...path removed...}/include/caption/utf8.h
-- Installing: ${...path removed...}/include/caption/scc.h
-- Installing: ${...path removed...}/include/caption/cea708.h
-- Installing: ${...path removed...}/include/caption/eia608.h
-- Installing: ${...path removed...}/include/caption/caption.h
-- Installing: ${...path removed...}/include/caption/eia608_charmap.h
```