### PR TITLE
Vtt segment support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ if (WIN32)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif()
 
-set(CMAKE_BUILD_TYPE Debug)
-
 # If CMAKE_BUILD_TYPE is not specified, then default to Release
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ if (WIN32)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif()
 
+set(CMAKE_BUILD_TYPE Debug)
+
 # If CMAKE_BUILD_TYPE is not specified, then default to Release
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
@@ -47,16 +49,17 @@ else()
 endif()
 
 set(CAPTION_SOURCES
-  src/utf8.c
-  src/srt.c
-  src/scc.c
   src/avc.c
-  src/xds.c
-  src/cea708.c
   src/caption.c
+  src/cea708.c
   src/eia608.c
   src/eia608_charmap.c
   src/eia608_from_utf8.c
+  src/scc.c
+  src/srt.c
+  src/utf8.c
+  src/vtt.c
+  src/xds.c
 )
 
 set(CAPTION_HEADERS
@@ -68,6 +71,7 @@ set(CAPTION_HEADERS
   caption/scc.h
   caption/srt.h
   caption/utf8.h
+  caption/vtt.h
   caption/xds.h
 )
 

--- a/caption/srt.h
+++ b/caption/srt.h
@@ -33,6 +33,7 @@ extern "C" {
 
 // timestamp and duration are in seconds
 typedef vtt_t srt_t;
+typedef vtt_block_t srt_cue_t;
 
 /*! \brief
     \param
@@ -56,6 +57,31 @@ void srt_free(srt_t* srt);
     \param
 */
 static inline vtt_block_t* srt_next(vtt_block_t* srt) { return srt->next; }
+
+/*! \brief
+    \param
+*/
+static inline utf8_char_t* srt_cue_data(srt_cue_t* cue) { return vtt_block_data(cue); }
+
+/*! \brief
+    \param
+*/
+static inline srt_cue_t* srt_cue_from_caption_frame(caption_frame_t* frame, srt_t *srt) { return vtt_cue_from_caption_frame(frame, srt); };
+
+/*! \brief
+    \param
+*/
+static inline void srt_cue_free_head(srt_t* srt) { vtt_cue_free_head(srt); };
+
+/*! \brief
+    \param
+*/
+static inline srt_cue_t* srt_cue_new(srt_t* srt, const utf8_char_t* data, size_t size) { return vtt_block_new(srt, data, size, VTT_CUE); };
+
+/*! \brief
+    \param
+*/
+static inline int srt_cue_to_caption_frame(srt_cue_t* cue, caption_frame_t* frame) { return vtt_cue_to_caption_frame(cue, frame); };
 
 void srt_dump(srt_t* srt);
 /*! \brief

--- a/caption/srt.h
+++ b/caption/srt.h
@@ -29,19 +29,15 @@ extern "C" {
 
 #include "caption.h"
 #include "eia608.h"
+#include "vtt.h"
 
 // timestamp and duration are in seconds
-typedef struct _srt_t {
-    struct _srt_t* next;
-    double timestamp;
-    double duration;
-    size_t aloc;
-} srt_t;
+typedef vtt_t srt_t;
 
 /*! \brief
     \param
 */
-srt_t* srt_new(const utf8_char_t* data, size_t size, double timestamp, srt_t* prev, srt_t** head);
+srt_t* srt_new();
 /*! \brief
     \param
 */
@@ -59,25 +55,8 @@ void srt_free(srt_t* srt);
 /*! \brief
     \param
 */
-static inline srt_t* srt_next(srt_t* srt) { return srt->next; }
-/*! \brief
-    \param
-*/
-static inline utf8_char_t* srt_data(srt_t* srt) { return (utf8_char_t*)(srt) + sizeof(srt_t); }
-// This only converts teh surrent SRT, It does not walk the list
-/*! \brief
-    \param
-*/
-int srt_to_caption_frame(srt_t* srt, caption_frame_t* frame);
+static inline vtt_block_t* srt_next(vtt_block_t* srt) { return srt->next; }
 
-// returns teh new srt. Head is not tracher internally.
-/*! \brief
-    \param
-*/
-srt_t* srt_from_caption_frame(caption_frame_t* frame, srt_t* prev, srt_t** head);
-/*! \brief
-    \param
-*/
 void srt_dump(srt_t* srt);
 /*! \brief
     \param

--- a/caption/utf8.h
+++ b/caption/utf8.h
@@ -80,7 +80,7 @@ utf8_size_t utf8_char_count(const char* data, size_t size);
 /*! \brief
     \param
 
-    returnes the length of the line in bytes triming not printable charcters at the end
+    returnes the length of the line in bytes triming not printable characters at the end
 */
 size_t utf8_trimmed_length(const utf8_char_t* data, size_t size);
 /*! \brief
@@ -112,6 +112,15 @@ int utf8_line_count(const utf8_char_t* data);
 #define UFTF_DEFAULT_MAX_FILE_SIZE = (50 * 1024 * 1024);
 
 utf8_char_t* utf8_load_text_file(const char* path, size_t* size);
+
+/*! \brief
+    \param
+
+    Compares 2 strings up to max len
+*/
+#ifndef strnstr
+char *strnstr(const char *string1, const char *string2, size_t len);
+#endif
 
 #ifdef __cplusplus
 }

--- a/caption/vtt.h
+++ b/caption/vtt.h
@@ -30,28 +30,56 @@ extern "C" {
 #include "caption.h"
 #include "eia608.h"
 
-// timestamp and duration are in seconds
-typedef struct _vtt_t {
-    struct _vtt_t* next;
+enum VTT_BLOCK_TYPE {
+    VTT_REGION = 0,
+    VTT_STYLE = 1,
+    VTT_NOTE = 2,
+    VTT_CUE = 3
+};
+
+// REGION represents a WebVTT Region
+typedef struct _region_t {
+    struct _region_t* next;
+    size_t id_size;
+    char *region_id;
+    size_t block_size;
+    char *block_text;
+} vtt_region_t;
+
+// Embedded CSS stylesheet
+typedef struct _style_t {
+    struct _style_t* next;
+    size_t block_size;
+    char *block_text;
+} vtt_style_t;
+
+// CUE represents a block of caption text
+typedef struct _cue_t {
+    struct _cue_t* next;
     double timestamp;
-    double duration;
-    size_t aloc;
+    double duration; // -1.0 for no duration
     char *cue_settings;
+    char *cue_id;
+    vtt_region_t *region;
+    size_t text_size;
+    char *block_text;
+} vtt_cue_t;
+
+// VTT files are a collection of REGION, STYLE and CUE blocks.
+// XXX: Comments (NOTE blocks) are ignored
+typedef struct _vtt_t {
+    vtt_region_t* region_head;
+    vtt_region_t* region_tail;
+    vtt_style_t* style_head;
+    vtt_style_t* style_tail;
+    vtt_cue_t* cue_head;
+    vtt_cue_t* cue_tail;
 } vtt_t;
 
 /*! \brief
     \param
 */
-vtt_t* vtt_new(const utf8_char_t* data, size_t size, double timestamp, vtt_t* prev, vtt_t** head);
-/*! \brief
-    \param
-*/
-vtt_t* vtt_free_head(vtt_t* head);
-// returns the head of the link list. must bee freed when done
-/*! \brief
-    \param
-*/
-vtt_t* vtt_parse(const utf8_char_t* data, size_t size);
+vtt_t* vtt_new();
 /*! \brief
     \param
 */
@@ -60,22 +88,68 @@ void vtt_free(vtt_t* vtt);
 /*! \brief
     \param
 */
-static inline vtt_t* vtt_next(vtt_t* vtt) { return vtt->next; }
+vtt_region_t *vtt_region_new(vtt_t* vtt, const utf8_char_t* data, size_t size);
 /*! \brief
     \param
 */
-static inline utf8_char_t* vtt_data(vtt_t* vtt) { return (utf8_char_t*)(vtt) + sizeof(vtt_t); }
-// This only converts teh surrent VTT, It does not walk the list
+void vtt_region_set_id(vtt_region_t* region, const utf8_char_t* data, size_t size);
 /*! \brief
     \param
 */
-int vtt_to_caption_frame(vtt_t* vtt, caption_frame_t* frame);
+vtt_region_t* vtt_region_free_head(vtt_region_t* region);
 
-// returns the new vtt. Head is not tracher internally.
 /*! \brief
     \param
 */
-vtt_t* vtt_from_caption_frame(caption_frame_t* frame, vtt_t* prev, vtt_t** head);
+vtt_style_t *vtt_style_new(vtt_t* vtt, const utf8_char_t* data, size_t size);
+/*! \brief
+    \param
+*/
+vtt_style_t* vtt_style_free_head(vtt_style_t* style);
+/*! \brief
+    \param
+*/
+vtt_cue_t* vtt_cue_new(vtt_t* vtt, const utf8_char_t* data, size_t size);
+/*! \brief
+    \param
+*/
+vtt_cue_t* vtt_cue_free_head(vtt_cue_t* head);
+
+// returns a vtt_t, containing linked lists of blocks. must be freed when done
+/*! \brief
+    \param
+*/
+vtt_t* vtt_parse(const utf8_char_t* data, size_t size);
+
+/*! \brief
+    \param
+*/
+static inline vtt_cue_t* vtt_cue_next(vtt_cue_t* cue) { return cue->next; }
+
+/*! \brief
+    \param
+*/
+static inline utf8_char_t* vtt_region_data(vtt_region_t* region) { return (utf8_char_t*)(region) + sizeof(vtt_region_t); }
+/*! \brief
+    \param
+*/
+static inline utf8_char_t* vtt_style_data(vtt_style_t* style) { return (utf8_char_t*)(style) + sizeof(vtt_style_t); }
+/*! \brief
+    \param
+*/
+static inline utf8_char_t* vtt_cue_data(vtt_cue_t* cue) { return (utf8_char_t*)(cue) + sizeof(vtt_cue_t); }
+
+// This only converts the current CUE, it does not walk the list
+/*! \brief
+    \param
+*/
+int vtt_cue_to_caption_frame(vtt_cue_t* cue, caption_frame_t* frame);
+
+// returns the new cue. Head is not tracher internally.
+/*! \brief
+    \param
+*/
+vtt_cue_t* vtt_cue_from_caption_frame(caption_frame_t* frame, vtt_t *vtt);
 /*! \brief
     \param
 */

--- a/caption/vtt.h
+++ b/caption/vtt.h
@@ -1,0 +1,87 @@
+/**********************************************************************************************/
+/* The MIT License                                                                            */
+/*                                                                                            */
+/* Copyright 2016-2017 Twitch Interactive, Inc. or its affiliates. All Rights Reserved.       */
+/*                                                                                            */
+/* Permission is hereby granted, free of charge, to any person obtaining a copy               */
+/* of this software and associated documentation files (the "Software"), to deal              */
+/* in the Software without restriction, including without limitation the rights               */
+/* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell                  */
+/* copies of the Software, and to permit persons to whom the Software is                      */
+/* furnished to do so, subject to the following conditions:                                   */
+/*                                                                                            */
+/* The above copyright notice and this permission notice shall be included in                 */
+/* all copies or substantial portions of the Software.                                        */
+/*                                                                                            */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR                 */
+/* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                   */
+/* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                */
+/* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                     */
+/* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,              */
+/* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                  */
+/* THE SOFTWARE.                                                                              */
+/**********************************************************************************************/
+#ifndef LIBCAPTION_VTT_H
+#define LIBCAPTION_VTT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "caption.h"
+#include "eia608.h"
+
+// timestamp and duration are in seconds
+typedef struct _vtt_t {
+    struct _vtt_t* next;
+    double timestamp;
+    double duration;
+    size_t aloc;
+    char *cue_settings;
+} vtt_t;
+
+/*! \brief
+    \param
+*/
+vtt_t* vtt_new(const utf8_char_t* data, size_t size, double timestamp, vtt_t* prev, vtt_t** head);
+/*! \brief
+    \param
+*/
+vtt_t* vtt_free_head(vtt_t* head);
+// returns the head of the link list. must bee freed when done
+/*! \brief
+    \param
+*/
+vtt_t* vtt_parse(const utf8_char_t* data, size_t size);
+/*! \brief
+    \param
+*/
+void vtt_free(vtt_t* vtt);
+
+/*! \brief
+    \param
+*/
+static inline vtt_t* vtt_next(vtt_t* vtt) { return vtt->next; }
+/*! \brief
+    \param
+*/
+static inline utf8_char_t* vtt_data(vtt_t* vtt) { return (utf8_char_t*)(vtt) + sizeof(vtt_t); }
+// This only converts teh surrent VTT, It does not walk the list
+/*! \brief
+    \param
+*/
+int vtt_to_caption_frame(vtt_t* vtt, caption_frame_t* frame);
+
+// returns the new vtt. Head is not tracher internally.
+/*! \brief
+    \param
+*/
+vtt_t* vtt_from_caption_frame(caption_frame_t* frame, vtt_t* prev, vtt_t** head);
+/*! \brief
+    \param
+*/
+void vtt_dump(vtt_t* vtt);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/caption/vtt.h
+++ b/caption/vtt.h
@@ -75,16 +75,32 @@ void vtt_free(vtt_t* vtt);
     \param
 */
 vtt_block_t* vtt_block_new(vtt_t* vtt, const utf8_char_t* data, size_t size, enum VTT_BLOCK_TYPE type);
+
 /*! \brief
     \param
 */
-vtt_block_t* vtt_block_free_head(vtt_block_t* head);
+void vtt_cue_free_head(vtt_t* vtt);
+
+/*! \brief
+    \param
+*/
+void vtt_style_free_head(vtt_t* vtt);
+
+/*! \brief
+    \param
+*/
+void vtt_region_free_head(vtt_t* vtt);
 
 // returns a vtt_t, containing linked lists of blocks. must be freed when done
 /*! \brief
     \param
 */
 vtt_t* vtt_parse(const utf8_char_t* data, size_t size);
+
+/*! \brief
+    \param
+*/
+vtt_t* _vtt_parse(const utf8_char_t* data, size_t size, int srt_mode);
 
 /*! \brief
     \param

--- a/caption/vtt.h
+++ b/caption/vtt.h
@@ -37,43 +37,29 @@ enum VTT_BLOCK_TYPE {
     VTT_CUE = 3
 };
 
-// REGION represents a WebVTT Region
-typedef struct _region_t {
-    struct _region_t* next;
-    size_t id_size;
-    char *region_id;
-    size_t block_size;
-    char *block_text;
-} vtt_region_t;
-
-// Embedded CSS stylesheet
-typedef struct _style_t {
-    struct _style_t* next;
-    size_t block_size;
-    char *block_text;
-} vtt_style_t;
-
 // CUE represents a block of caption text
-typedef struct _cue_t {
-    struct _cue_t* next;
+typedef struct _vtt_block_t {
+    struct _vtt_block_t* next;
+    enum VTT_BLOCK_TYPE type;
+    // CUE-Only
     double timestamp;
     double duration; // -1.0 for no duration
     char *cue_settings;
     char *cue_id;
-    vtt_region_t *region;
+    // Standard block data
     size_t text_size;
     char *block_text;
-} vtt_cue_t;
+} vtt_block_t;
 
 // VTT files are a collection of REGION, STYLE and CUE blocks.
 // XXX: Comments (NOTE blocks) are ignored
 typedef struct _vtt_t {
-    vtt_region_t* region_head;
-    vtt_region_t* region_tail;
-    vtt_style_t* style_head;
-    vtt_style_t* style_tail;
-    vtt_cue_t* cue_head;
-    vtt_cue_t* cue_tail;
+    vtt_block_t* region_head;
+    vtt_block_t* region_tail;
+    vtt_block_t* style_head;
+    vtt_block_t* style_tail;
+    vtt_block_t* cue_head;
+    vtt_block_t* cue_tail;
 } vtt_t;
 
 /*! \brief
@@ -88,32 +74,11 @@ void vtt_free(vtt_t* vtt);
 /*! \brief
     \param
 */
-vtt_region_t *vtt_region_new(vtt_t* vtt, const utf8_char_t* data, size_t size);
+vtt_block_t* vtt_block_new(vtt_t* vtt, const utf8_char_t* data, size_t size, enum VTT_BLOCK_TYPE type);
 /*! \brief
     \param
 */
-void vtt_region_set_id(vtt_region_t* region, const utf8_char_t* data, size_t size);
-/*! \brief
-    \param
-*/
-vtt_region_t* vtt_region_free_head(vtt_region_t* region);
-
-/*! \brief
-    \param
-*/
-vtt_style_t *vtt_style_new(vtt_t* vtt, const utf8_char_t* data, size_t size);
-/*! \brief
-    \param
-*/
-vtt_style_t* vtt_style_free_head(vtt_style_t* style);
-/*! \brief
-    \param
-*/
-vtt_cue_t* vtt_cue_new(vtt_t* vtt, const utf8_char_t* data, size_t size);
-/*! \brief
-    \param
-*/
-vtt_cue_t* vtt_cue_free_head(vtt_cue_t* head);
+vtt_block_t* vtt_block_free_head(vtt_block_t* head);
 
 // returns a vtt_t, containing linked lists of blocks. must be freed when done
 /*! \brief
@@ -124,32 +89,35 @@ vtt_t* vtt_parse(const utf8_char_t* data, size_t size);
 /*! \brief
     \param
 */
-static inline vtt_cue_t* vtt_cue_next(vtt_cue_t* cue) { return cue->next; }
+static inline vtt_block_t* vtt_cue_next(vtt_block_t* block) { return block->next; }
 
 /*! \brief
     \param
 */
-static inline utf8_char_t* vtt_region_data(vtt_region_t* region) { return (utf8_char_t*)(region) + sizeof(vtt_region_t); }
+static inline utf8_char_t* vtt_block_data(vtt_block_t* block) { return (utf8_char_t*)(block) + sizeof(vtt_block_t); }
+
 /*! \brief
     \param
 */
-static inline utf8_char_t* vtt_style_data(vtt_style_t* style) { return (utf8_char_t*)(style) + sizeof(vtt_style_t); }
-/*! \brief
-    \param
-*/
-static inline utf8_char_t* vtt_cue_data(vtt_cue_t* cue) { return (utf8_char_t*)(cue) + sizeof(vtt_cue_t); }
+static inline void vtt_crack_time(double tt, int* hh, int* mm, int* ss, int* ms)
+{
+    (*ms) = (int)((int64_t)(tt * 1000) % 1000);
+    (*ss) = (int)((int64_t)(tt) % 60);
+    (*mm) = (int)((int64_t)(tt / (60)) % 60);
+    (*hh) = (int)((int64_t)(tt / (60 * 60)));
+}
 
 // This only converts the current CUE, it does not walk the list
 /*! \brief
     \param
 */
-int vtt_cue_to_caption_frame(vtt_cue_t* cue, caption_frame_t* frame);
+int vtt_cue_to_caption_frame(vtt_block_t* cue, caption_frame_t* frame);
 
-// returns the new cue. Head is not tracher internally.
+// returns the new cue
 /*! \brief
     \param
 */
-vtt_cue_t* vtt_cue_from_caption_frame(caption_frame_t* frame, vtt_t *vtt);
+vtt_block_t* vtt_cue_from_caption_frame(caption_frame_t* frame, vtt_t *vtt);
 /*! \brief
     \param
 */

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_BUILD_TYPE Debug)
+
 add_executable(flv2srt flv2srt.c flv.c)
 target_link_libraries(flv2srt caption)
 install(TARGETS flv2srt DESTINATION bin)
@@ -30,6 +32,10 @@ add_executable(srtdump srtdump.c)
 target_link_libraries(srtdump caption)
 install(TARGETS srtdump DESTINATION bin)
 
+add_executable(vttdump vttdump.c)
+target_link_libraries(vttdump caption)
+install(TARGETS vttdump DESTINATION bin)
+
 add_executable(rollup rollup.c flv.c)
 target_link_libraries(rollup caption)
 install(TARGETS rollup DESTINATION bin)
@@ -37,6 +43,10 @@ install(TARGETS rollup DESTINATION bin)
 add_executable(party party.c flv.c)
 target_link_libraries(party caption)
 install(TARGETS party DESTINATION bin)
+
+add_executable(vttsegmenter vttsegmenter.c)
+target_link_libraries(vttsegmenter caption)
+install(TARGETS vttsegmenter DESTINATION bin)
 
 #add_executable(rtmpspit rtmpspit.c  flv.c)
 #target_link_libraries(rtmpspit caption rtmp)

--- a/examples/flv+srt.c
+++ b/examples/flv+srt.c
@@ -79,7 +79,7 @@ srt_t* srt_from_fd(int fd)
         int ret = fd_read(fd, &c, 1, &eof);
 
         if (eof || (1 == ret && 0 == c)) {
-            srt_t* srt = vtt_parse(&g_srt_data[0], g_srt_size);
+            srt_t* srt = srt_parse(&g_srt_data[0], g_srt_size);
             g_srt_size = 0;
             return srt;
         }
@@ -102,7 +102,7 @@ int main(int argc, char** argv)
 {
     flvtag_t tag;
     srt_t *old_srt = NULL;
-    vtt_block_t *next_cue = NULL;
+    srt_cue_t *next_cue = NULL;
     double timestamp, offset = 0, clear_timestamp = 0;
     int has_audio, has_video;
     FILE* flv = flv_open_read(argv[1]);
@@ -140,9 +140,9 @@ int main(int argc, char** argv)
 
         if (flvtag_avcpackettype_nalu == flvtag_avcpackettype(&tag)) {
             if (next_cue && (offset + next_cue->timestamp) <= timestamp) {
-                fprintf(stderr, "T: %0.02f (%0.02fs):\n%s\n", (offset + next_cue->timestamp), next_cue->duration, vtt_block_data(next_cue));
+                fprintf(stderr, "T: %0.02f (%0.02fs):\n%s\n", (offset + next_cue->timestamp), next_cue->duration, srt_cue_data(next_cue));
                 clear_timestamp = (offset + next_cue->timestamp) + next_cue->duration;
-                flvtag_addcaption_text(&tag, vtt_block_data(next_cue));
+                flvtag_addcaption_text(&tag, srt_cue_data(next_cue));
                 next_cue = next_cue->next;
             } else if (0 <= clear_timestamp && clear_timestamp <= timestamp) {
                 fprintf(stderr, "T: %0.02f: [CAPTIONS CLEARED]\n", timestamp);

--- a/examples/flv+srt.c
+++ b/examples/flv+srt.c
@@ -79,7 +79,7 @@ srt_t* srt_from_fd(int fd)
         int ret = fd_read(fd, &c, 1, &eof);
 
         if (eof || (1 == ret && 0 == c)) {
-            srt_t* srt = srt_parse(&g_srt_data[0], g_srt_size);
+            srt_t* srt = vtt_parse(&g_srt_data[0], g_srt_size);
             g_srt_size = 0;
             return srt;
         }
@@ -101,7 +101,8 @@ srt_t* srt_from_fd(int fd)
 int main(int argc, char** argv)
 {
     flvtag_t tag;
-    srt_t *old_srt = 0, *nxt_srt = 0;
+    srt_t *old_srt = NULL;
+    vtt_block_t *next_cue = NULL;
     double timestamp, offset = 0, clear_timestamp = 0;
     int has_audio, has_video;
     FILE* flv = flv_open_read(argv[1]);
@@ -123,24 +124,26 @@ int main(int argc, char** argv)
 
     while (flv_read_tag(flv, &tag)) {
 
-        srt_t* new_srt = srt_from_fd(fd);
+        srt_t* cur_srt = srt_from_fd(fd);
         timestamp = flvtag_pts_seconds(&tag);
 
-        if (new_srt) {
+        if (cur_srt) {
             fprintf(stderr, "Loaded new SRT at time %f\n", timestamp);
-            srt_free(old_srt);
-            old_srt = new_srt;
-            nxt_srt = new_srt;
+            if (old_srt != NULL) {
+                srt_free(old_srt);
+            }
+            old_srt = cur_srt;
             offset = timestamp;
             clear_timestamp = timestamp;
+            next_cue = cur_srt->cue_head;
         }
 
         if (flvtag_avcpackettype_nalu == flvtag_avcpackettype(&tag)) {
-            if (nxt_srt && (offset + nxt_srt->timestamp) <= timestamp) {
-                fprintf(stderr, "T: %0.02f (%0.02fs):\n%s\n", (offset + nxt_srt->timestamp), nxt_srt->duration, srt_data(nxt_srt));
-                clear_timestamp = (offset + nxt_srt->timestamp) + nxt_srt->duration;
-                flvtag_addcaption_text(&tag, srt_data(nxt_srt));
-                nxt_srt = nxt_srt->next;
+            if (next_cue && (offset + next_cue->timestamp) <= timestamp) {
+                fprintf(stderr, "T: %0.02f (%0.02fs):\n%s\n", (offset + next_cue->timestamp), next_cue->duration, vtt_block_data(next_cue));
+                clear_timestamp = (offset + next_cue->timestamp) + next_cue->duration;
+                flvtag_addcaption_text(&tag, vtt_block_data(next_cue));
+                next_cue = next_cue->next;
             } else if (0 <= clear_timestamp && clear_timestamp <= timestamp) {
                 fprintf(stderr, "T: %0.02f: [CAPTIONS CLEARED]\n", timestamp);
                 flvtag_addcaption_text(&tag, NULL);

--- a/examples/flv2srt.c
+++ b/examples/flv2srt.c
@@ -66,7 +66,7 @@ int main(int argc, char** argv)
                     // sei_dump(&sei);
 
                     if (LIBCAPTION_READY == sei_to_caption_frame(&sei, &frame)) {
-                        vtt_cue_from_caption_frame(&frame, srt);
+                        srt_cue_from_caption_frame(&frame, srt);
                     }
 
                     // caption_frame_dump(&frame);

--- a/examples/flv2srt.c
+++ b/examples/flv2srt.c
@@ -32,7 +32,7 @@ int main(int argc, char** argv)
 
     sei_t sei;
     flvtag_t tag;
-    srt_t *srt = 0, *head = 0;
+    srt_t *srt = 0;
     int has_audio, has_video;
     caption_frame_t frame;
 
@@ -40,6 +40,7 @@ int main(int argc, char** argv)
     caption_frame_init(&frame);
 
     FILE* flv = flv_open_read(path);
+    srt = srt_new();
 
     if (!flv_read_header(flv, &has_audio, &has_video)) {
         fprintf(stderr, "'%s' Not an flv file\n", path);
@@ -65,7 +66,7 @@ int main(int argc, char** argv)
                     // sei_dump(&sei);
 
                     if (LIBCAPTION_READY == sei_to_caption_frame(&sei, &frame)) {
-                        srt = srt_from_caption_frame(&frame, srt, &head);
+                        vtt_cue_from_caption_frame(&frame, srt);
                     }
 
                     // caption_frame_dump(&frame);
@@ -75,8 +76,8 @@ int main(int argc, char** argv)
         }
     }
 
-    srt_dump(head);
-    srt_free(head);
+    srt_dump(srt);
+    srt_free(srt);
 
     return 1;
 }

--- a/examples/rollup.c
+++ b/examples/rollup.c
@@ -49,7 +49,7 @@ void append_caption(const utf8_char_t* data, srt_t* srt)
 
         // fprintf (stderr,"%.*s\n", line_length, data);
         double timestamp = srt->cue_tail ? srt->cue_tail->timestamp + SECONDS_PER_LINE : 0;
-        vtt_block_t *cue = vtt_block_new(srt, data, line_length, VTT_CUE);
+        srt_cue_t *cue = srt_cue_new(srt, data, line_length);
         cue->timestamp = timestamp;
         cue->duration = SECONDS_PER_LINE;
 
@@ -83,9 +83,9 @@ int main(int argc, char** argv)
 
     while (flv_read_tag(flv, &tag)) {
         if (srt->cue_head && flvtag_avcpackettype_nalu == flvtag_avcpackettype(&tag) && srt->cue_head->timestamp <= flvtag_pts_seconds(&tag)) {
-            fprintf(stderr, "%f %s\n", flvtag_pts_seconds(&tag), vtt_block_data(srt->cue_head));
-            flvtag_addcaption_text(&tag, vtt_block_data(srt->cue_head));
-            vtt_cue_free_head(srt);
+            fprintf(stderr, "%f %s\n", flvtag_pts_seconds(&tag), srt_cue_data(srt->cue_head));
+            flvtag_addcaption_text(&tag, srt_cue_data(srt->cue_head));
+            srt_cue_free_head(srt);
         }
 
         flv_write_tag(out, &tag);

--- a/examples/scc2srt.c
+++ b/examples/scc2srt.c
@@ -47,7 +47,7 @@ int main(int argc, char** argv)
             // eia608_dump (scc->cc_data[i]);
 
             if (LIBCAPTION_READY == caption_frame_decode(&frame, scc->cc_data[i], scc->timestamp)) {
-                vtt_cue_from_caption_frame(&frame, srt);
+                srt_cue_from_caption_frame(&frame, srt);
             }
         }
 

--- a/examples/scc2srt.c
+++ b/examples/scc2srt.c
@@ -33,27 +33,29 @@ int main(int argc, char** argv)
     scc_t* scc = NULL;
     size_t scc_size = 0;
     caption_frame_t frame;
-    srt_t *srt = 0, *head = 0;
+    srt_t *srt = 0;
     utf8_char_t* scc_data_ptr = utf8_load_text_file(argv[1], &scc_size);
     utf8_char_t* scc_data = scc_data_ptr;
 
     caption_frame_init(&frame);
     scc_data += scc_to_608(&scc, scc_data);
 
+    srt = srt_new();
+
     while (scc->cc_size) {
         for (i = 0; i < scc->cc_size; ++i) {
             // eia608_dump (scc->cc_data[i]);
 
             if (LIBCAPTION_READY == caption_frame_decode(&frame, scc->cc_data[i], scc->timestamp)) {
-                srt = srt_from_caption_frame(&frame, srt, &head);
+                vtt_cue_from_caption_frame(&frame, srt);
             }
         }
 
         scc_data += scc_to_608(&scc, scc_data);
     }
 
-    srt_dump(head);
-    srt_free(head);
+    srt_dump(srt);
+    srt_free(srt);
     free(scc_data_ptr);
     return EXIT_SUCCESS;
 }

--- a/examples/srt2vtt.c
+++ b/examples/srt2vtt.c
@@ -26,36 +26,20 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define MAX_SRT_SIZE (10 * 1024 * 1024)
-#define MAX_READ_SIZE 4096
-
-size_t read_file(FILE* file, utf8_char_t* data, size_t size)
-{
-    size_t read, totl = 0;
-
-    while (0 < (read = fread(data, 1, MAX_READ_SIZE < size ? MAX_READ_SIZE : size, file))) {
-        totl += read;
-        data += read;
-        size -= read;
-    }
-
-    return totl;
-}
-
 int main(int argc, char** argv)
 {
     if (argc < 2) {
+        fprintf(stderr, "Usage: srt2vtt input.srt\n");
         return 0;
     }
 
-    FILE* file = fopen(argv[1], "r");
-
-    if (!file) {
-        return 0;
+    size_t size;
+    utf8_char_t* data = utf8_load_text_file(argv[1], &size);
+    if (data == NULL) {
+        fprintf(stderr, "Failed to load input file\n");
+        return 1;
     }
 
-    utf8_char_t* data = malloc(MAX_SRT_SIZE);
-    size_t size = read_file(file, data, MAX_SRT_SIZE);
     srt_t* head = srt_parse(data, size);
     vtt_dump(head);
     srt_free(head);

--- a/examples/srtdump.c
+++ b/examples/srtdump.c
@@ -48,6 +48,7 @@ int main(int argc, char** argv)
 {
     srt_t* srt;
     caption_frame_t frame;
+    vtt_block_t* block;
 
     if (argc < 2) {
         return 0;
@@ -59,15 +60,15 @@ int main(int argc, char** argv)
         return 0;
     }
 
-    utf8_char_t* data = (utf8_char_t*)malloc(MAX_SRT_SIZE);
-    size_t size = read_file(file, data, MAX_SRT_SIZE);
-    srt_t* head = srt_parse(data, size);
-
-    for (srt = head; srt; srt = srt->next) {
+    size_t size;
+    utf8_char_t* data = utf8_load_text_file(argv[1], &size);
+    srt = srt_parse(data, size);
+    
+    for (block = srt->cue_head; block; block = block->next) {
         caption_frame_init(&frame);
-        srt_to_caption_frame(srt, &frame);
+        vtt_cue_to_caption_frame(block, &frame);
         caption_frame_dump(&frame);
     }
 
-    srt_free(head);
+    srt_free(srt);
 }

--- a/examples/srtdump.c
+++ b/examples/srtdump.c
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
 {
     srt_t* srt;
     caption_frame_t frame;
-    vtt_block_t* block;
+    srt_cue_t* cue;
 
     if (argc < 2) {
         return 0;
@@ -64,9 +64,9 @@ int main(int argc, char** argv)
     utf8_char_t* data = utf8_load_text_file(argv[1], &size);
     srt = srt_parse(data, size);
     
-    for (block = srt->cue_head; block; block = block->next) {
+    for (cue = srt->cue_head; cue; cue = cue->next) {
         caption_frame_init(&frame);
-        vtt_cue_to_caption_frame(block, &frame);
+        srt_cue_to_caption_frame(cue, &frame);
         caption_frame_dump(&frame);
     }
 

--- a/examples/ts2srt.c
+++ b/examples/ts2srt.c
@@ -33,12 +33,15 @@ int main(int argc, char** argv)
     ts_t ts;
     sei_t sei;
     avcnalu_t nalu;
-    srt_t *srt = 0, *head = 0;
+    srt_t *srt;
+    vtt_block_t *block;
     caption_frame_t frame;
     uint8_t pkt[TS_PACKET_SIZE];
     ts_init(&ts);
     avcnalu_init(&nalu);
     caption_frame_init(&frame);
+
+    srt = srt_new();
 
     FILE* file = fopen(path, "rb+");
 
@@ -74,9 +77,7 @@ int main(int argc, char** argv)
 
                         if (LIBCAPTION_READY == sei_to_caption_frame(&sei, &frame)) {
                             // caption_frame_dump(&frame);
-                            srt = srt_from_caption_frame(&frame, srt, &head);
-
-                            // srt_dump (srt);
+                            vtt_cue_from_caption_frame(&frame, srt);
                         }
 
                         sei_free(&sei);
@@ -94,8 +95,8 @@ int main(int argc, char** argv)
         }
     }
 
-    srt_dump(head);
-    srt_free(head);
+    srt_dump(srt);
+    srt_free(srt);
 
     return 1;
 }

--- a/examples/ts2srt.c
+++ b/examples/ts2srt.c
@@ -34,7 +34,6 @@ int main(int argc, char** argv)
     sei_t sei;
     avcnalu_t nalu;
     srt_t *srt;
-    vtt_block_t *block;
     caption_frame_t frame;
     uint8_t pkt[TS_PACKET_SIZE];
     ts_init(&ts);
@@ -77,7 +76,7 @@ int main(int argc, char** argv)
 
                         if (LIBCAPTION_READY == sei_to_caption_frame(&sei, &frame)) {
                             // caption_frame_dump(&frame);
-                            vtt_cue_from_caption_frame(&frame, srt);
+                            srt_cue_from_caption_frame(&frame, srt);
                         }
 
                         sei_free(&sei);

--- a/examples/vttdump.c
+++ b/examples/vttdump.c
@@ -46,7 +46,6 @@ size_t read_file(FILE* file, utf8_char_t* data, size_t size)
 
 int main(int argc, char** argv)
 {
-    vtt_t* vtt;
     caption_frame_t frame;
 
     if (argc < 2) {
@@ -61,13 +60,13 @@ int main(int argc, char** argv)
 
     utf8_char_t* data = (utf8_char_t*)malloc(MAX_VTT_SIZE);
     size_t size = read_file(file, data, MAX_VTT_SIZE);
-    vtt_t* head = vtt_parse(data, size);
+    vtt_t* vtt = vtt_parse(data, size);
 
-    for (vtt = head; vtt; vtt = vtt->next) {
+    for (vtt_cue_t* cue = vtt->cue_head; cue != NULL; cue = cue->next) {
         caption_frame_init(&frame);
-        vtt_to_caption_frame(vtt, &frame);
+        vtt_cue_to_caption_frame(cue, &frame);
         caption_frame_dump(&frame);
     }
 
-    vtt_free(head);
+    vtt_free(vtt);
 }

--- a/examples/vttdump.c
+++ b/examples/vttdump.c
@@ -1,0 +1,73 @@
+/**********************************************************************************************/
+/* The MIT License                                                                            */
+/*                                                                                            */
+/* Copyright 2016-2017 Twitch Interactive, Inc. or its affiliates. All Rights Reserved.       */
+/*                                                                                            */
+/* Permission is hereby granted, free of charge, to any person obtaining a copy               */
+/* of this software and associated documentation files (the "Software"), to deal              */
+/* in the Software without restriction, including without limitation the rights               */
+/* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell                  */
+/* copies of the Software, and to permit persons to whom the Software is                      */
+/* furnished to do so, subject to the following conditions:                                   */
+/*                                                                                            */
+/* The above copyright notice and this permission notice shall be included in                 */
+/* all copies or substantial portions of the Software.                                        */
+/*                                                                                            */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR                 */
+/* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                   */
+/* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                */
+/* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                     */
+/* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,              */
+/* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                  */
+/* THE SOFTWARE.                                                                              */
+/**********************************************************************************************/
+#include "avc.h"
+#include "vtt.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+// #include "sei.h"
+
+#define MAX_VTT_SIZE (10 * 1024 * 1024)
+#define MAX_READ_SIZE 4096
+
+size_t read_file(FILE* file, utf8_char_t* data, size_t size)
+{
+    size_t read, totl = 0;
+
+    while (0 < (read = fread(data, 1, MAX_READ_SIZE < size ? MAX_READ_SIZE : size, file))) {
+        totl += read;
+        data += read;
+        size -= read;
+    }
+
+    return totl;
+}
+
+int main(int argc, char** argv)
+{
+    vtt_t* vtt;
+    caption_frame_t frame;
+
+    if (argc < 2) {
+        return 0;
+    }
+
+    FILE* file = fopen(argv[1], "r");
+
+    if (!file) {
+        return 0;
+    }
+
+    utf8_char_t* data = (utf8_char_t*)malloc(MAX_VTT_SIZE);
+    size_t size = read_file(file, data, MAX_VTT_SIZE);
+    vtt_t* head = vtt_parse(data, size);
+
+    for (vtt = head; vtt; vtt = vtt->next) {
+        caption_frame_init(&frame);
+        vtt_to_caption_frame(vtt, &frame);
+        caption_frame_dump(&frame);
+    }
+
+    vtt_free(head);
+}

--- a/examples/vttdump.c
+++ b/examples/vttdump.c
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
     utf8_char_t* data = utf8_load_text_file(argv[1], &size);
     vtt_t* vtt = vtt_parse(data, size);
 
-    for (vtt_cue_t* cue = vtt->cue_head; cue != NULL; cue = cue->next) {
+    for (vtt_block_t* cue = vtt->cue_head; cue != NULL; cue = cue->next) {
         caption_frame_init(&frame);
         vtt_cue_to_caption_frame(cue, &frame);
         caption_frame_dump(&frame);

--- a/examples/vttdump.c
+++ b/examples/vttdump.c
@@ -37,6 +37,7 @@ int main(int argc, char** argv)
 
     size_t size;
     utf8_char_t* data = utf8_load_text_file(argv[1], &size);
+
     vtt_t* vtt = vtt_parse(data, size);
 
     for (vtt_block_t* cue = vtt->cue_head; cue != NULL; cue = cue->next) {

--- a/examples/vttdump.c
+++ b/examples/vttdump.c
@@ -26,23 +26,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-// #include "sei.h"
-
-#define MAX_VTT_SIZE (10 * 1024 * 1024)
-#define MAX_READ_SIZE 4096
-
-size_t read_file(FILE* file, utf8_char_t* data, size_t size)
-{
-    size_t read, totl = 0;
-
-    while (0 < (read = fread(data, 1, MAX_READ_SIZE < size ? MAX_READ_SIZE : size, file))) {
-        totl += read;
-        data += read;
-        size -= read;
-    }
-
-    return totl;
-}
 
 int main(int argc, char** argv)
 {
@@ -52,14 +35,8 @@ int main(int argc, char** argv)
         return 0;
     }
 
-    FILE* file = fopen(argv[1], "r");
-
-    if (!file) {
-        return 0;
-    }
-
-    utf8_char_t* data = (utf8_char_t*)malloc(MAX_VTT_SIZE);
-    size_t size = read_file(file, data, MAX_VTT_SIZE);
+    size_t size;
+    utf8_char_t* data = utf8_load_text_file(argv[1], &size);
     vtt_t* vtt = vtt_parse(data, size);
 
     for (vtt_cue_t* cue = vtt->cue_head; cue != NULL; cue = cue->next) {

--- a/examples/vttsegmenter.c
+++ b/examples/vttsegmenter.c
@@ -1,0 +1,96 @@
+/**********************************************************************************************/
+/* The MIT License                                                                            */
+/*                                                                                            */
+/* Copyright 2016-2017 Twitch Interactive, Inc. or its affiliates. All Rights Reserved.       */
+/*                                                                                            */
+/* Permission is hereby granted, free of charge, to any person obtaining a copy               */
+/* of this software and associated documentation files (the "Software"), to deal              */
+/* in the Software without restriction, including without limitation the rights               */
+/* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell                  */
+/* copies of the Software, and to permit persons to whom the Software is                      */
+/* furnished to do so, subject to the following conditions:                                   */
+/*                                                                                            */
+/* The above copyright notice and this permission notice shall be included in                 */
+/* all copies or substantial portions of the Software.                                        */
+/*                                                                                            */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR                 */
+/* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                   */
+/* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                */
+/* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                     */
+/* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,              */
+/* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                  */
+/* THE SOFTWARE.                                                                              */
+/**********************************************************************************************/
+#include "avc.h"
+#include "vtt.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+// #include "sei.h"
+
+#define MAX_VTT_SIZE (10 * 1024 * 1024)
+#define MAX_READ_SIZE 4096
+
+size_t read_file(FILE* file, utf8_char_t* data, size_t size)
+{
+    size_t read, totl = 0;
+
+    while (0 < (read = fread(data, 1, MAX_READ_SIZE < size ? MAX_READ_SIZE : size, file))) {
+        totl += read;
+        data += read;
+        size -= read;
+    }
+
+    return totl;
+}
+
+int main(int argc, char** argv)
+{
+    vtt_t* vtt;
+    caption_frame_t frame;
+
+    if (argc < 4) {
+        return 0;
+    }
+
+    FILE* file = fopen(argv[1], "r");
+
+    if (!file) {
+        return 0;
+    }
+
+    double segment_size;
+    double duration;
+    if (1 != sscanf(argv[2], "%lf", &segment_size)) {
+        return 0;
+    }
+    if (1 != sscanf(argv[3], "%lf", &duration)) {
+        return 0;
+    }
+
+    printf("Segment size: %lf\n", segment_size);
+    printf("Duration: %lf\n", duration);
+
+    utf8_char_t* data = (utf8_char_t*)malloc(MAX_VTT_SIZE);
+    size_t size = read_file(file, data, MAX_VTT_SIZE);
+    printf("First chars: %.*s\n", 6, data);
+    vtt_t* head = vtt_parse(data, size);
+    if (head == NULL) {
+        printf("Failed to parse vtt\n");
+        return 0;
+    }
+
+    for (int i = 0; i * segment_size < duration; i++) {
+        printf("Segment: %d\n", i);
+    }
+
+    for (vtt = head; vtt; vtt = vtt->next) {
+        printf("timestamp: %lf\n", vtt->timestamp);
+        caption_frame_init(&frame);
+        vtt_to_caption_frame(vtt, &frame);
+        caption_frame_dump(&frame);
+    }
+    printf("Done\n");
+
+    vtt_free(head);
+}

--- a/examples/vttsegmenter.c
+++ b/examples/vttsegmenter.c
@@ -74,8 +74,8 @@ int main(int argc, char** argv)
     utf8_char_t* data = (utf8_char_t*)malloc(MAX_VTT_SIZE);
     size_t size = read_file(file, data, MAX_VTT_SIZE);
     printf("First chars: %.*s\n", 6, data);
-    vtt_t* head = vtt_parse(data, size);
-    if (head == NULL) {
+    vtt = vtt_parse(data, size);
+    if (vtt == NULL) {
         printf("Failed to parse vtt\n");
         return 0;
     }
@@ -84,13 +84,13 @@ int main(int argc, char** argv)
         printf("Segment: %d\n", i);
     }
 
-    for (vtt = head; vtt; vtt = vtt->next) {
-        printf("timestamp: %lf\n", vtt->timestamp);
+    for (vtt_cue_t* cue = vtt->cue_head; cue != NULL; cue = cue->next) {
+        printf("timestamp: %lf\n", cue->timestamp);
         caption_frame_init(&frame);
-        vtt_to_caption_frame(vtt, &frame);
+        vtt_cue_to_caption_frame(cue, &frame);
         caption_frame_dump(&frame);
     }
     printf("Done\n");
 
-    vtt_free(head);
+    vtt_free(vtt);
 }

--- a/examples/vttsegmenter.c
+++ b/examples/vttsegmenter.c
@@ -31,66 +31,119 @@
 #define MAX_VTT_SIZE (10 * 1024 * 1024)
 #define MAX_READ_SIZE 4096
 
-size_t read_file(FILE* file, utf8_char_t* data, size_t size)
+void vtt_write_header(FILE* vttFile)
 {
-    size_t read, totl = 0;
-
-    while (0 < (read = fread(data, 1, MAX_READ_SIZE < size ? MAX_READ_SIZE : size, file))) {
-        totl += read;
-        data += read;
-        size -= read;
-    }
-
-    return totl;
+    fprintf(vttFile, "WEBVTT\r\n\r\n");
 }
 
+void vtt_write_block(vtt_block_t* block, FILE* vttFile)
+{
+    switch (block->type) 
+    {
+        case VTT_REGION:
+            fprintf(vttFile, "REGION\r\n%s\r\n\r\n", vtt_block_data(block));
+            break;
+        case VTT_STYLE:
+            fprintf(vttFile, "STYLE\r\n%s\r\n\r\n", vtt_block_data(block));
+            break;
+        case VTT_NOTE:
+            fprintf(vttFile, "NOTE\r\n%s\r\n\r\n", vtt_block_data(block));
+            break;
+        case VTT_CUE:
+        {
+            if (block->cue_id != NULL) {
+                fprintf(vttFile, "%s\r\n", block->cue_id);
+            }
+
+            int hh1, hh2, mm1, mm2, ss1, ss2, ms1, ms2;
+            vtt_crack_time(block->timestamp, &hh1, &mm1, &ss1, &ms1);
+            vtt_crack_time(block->timestamp + block->duration, &hh2, &mm2, &ss2, &ms2);
+        
+            fprintf(vttFile, "%d:%02d:%02d.%03d --> %02d:%02d:%02d.%03d",
+                hh1, mm1, ss1, ms1, hh2, mm2, ss2, ms2);
+            
+            if (block->cue_settings != NULL) {
+                printf(" %s", block->cue_settings);
+            }
+
+            fprintf(vttFile, "\r\n%s\r\n\r\n", vtt_block_data(block));
+        }
+            break;
+    }
+}
+
+/**
+ * vttsegmenter filename.vtt segment_size duration output_pattern_%05d.vtt
+ */
 int main(int argc, char** argv)
 {
-    vtt_t* vtt;
-    caption_frame_t frame;
-
-    if (argc < 4) {
-        return 0;
-    }
-
-    FILE* file = fopen(argv[1], "r");
-
-    if (!file) {
+    if (argc != 5) {
+        fprintf(stderr, "Usage: vttsegmenter filename.vtt segment_size duration output%%05d.vtt\n");
         return 0;
     }
 
     double segment_size;
     double duration;
     if (1 != sscanf(argv[2], "%lf", &segment_size)) {
-        return 0;
+        return 1;
     }
     if (1 != sscanf(argv[3], "%lf", &duration)) {
-        return 0;
+        return 1;
     }
 
-    printf("Segment size: %lf\n", segment_size);
-    printf("Duration: %lf\n", duration);
-
-    utf8_char_t* data = (utf8_char_t*)malloc(MAX_VTT_SIZE);
-    size_t size = read_file(file, data, MAX_VTT_SIZE);
-    printf("First chars: %.*s\n", 6, data);
-    vtt = vtt_parse(data, size);
+    size_t size;
+    utf8_char_t* data = utf8_load_text_file(argv[1], &size);
+    if (data == NULL) {
+        fprintf(stderr, "Failed to load input file\n");
+        return 1;
+    }
+    vtt_t* vtt = vtt_parse(data, size);
     if (vtt == NULL) {
-        printf("Failed to parse vtt\n");
-        return 0;
+        fprintf(stderr, "Failed to parse vtt\n");
+        return 1;
     }
+
+    char filename[1024];
 
     for (int i = 0; i * segment_size < duration; i++) {
-        printf("Segment: %d\n", i);
-    }
+        if (snprintf(filename, 1024, argv[4], i) < 0) {
+            fprintf(stderr, "Invalid filename pattern for output\n");
+            return 1;
+        }
 
-    for (vtt_cue_t* cue = vtt->cue_head; cue != NULL; cue = cue->next) {
-        printf("timestamp: %lf\n", cue->timestamp);
-        caption_frame_init(&frame);
-        vtt_cue_to_caption_frame(cue, &frame);
-        caption_frame_dump(&frame);
+        FILE* outputFile = fopen(filename, "w");
+        if (outputFile == NULL) {
+            fprintf(stderr, "Failed to open output file for reading: '%s'\n", filename);
+            return 1;
+        }
+
+        vtt_write_header(outputFile);
+        vtt_block_t* region = vtt->region_head;
+        while (region != NULL) {
+            vtt_write_block(region, outputFile);
+            region = region->next;
+        }
+
+        vtt_block_t* style = vtt->style_head;
+        while (style != NULL) {
+            vtt_write_block(style, outputFile);
+            style = style->next;
+        }
+
+        double segment_start = i * segment_size;
+        double segment_end = (i + 1) * segment_size;
+
+
+        vtt_block_t* cue = vtt->cue_head;
+        while (cue != NULL) {
+            if ((cue->timestamp < segment_end) && ((cue->timestamp + cue->duration) > segment_start)) {
+                vtt_write_block(cue, outputFile);                
+            }
+            cue = cue->next;
+        }
+
+        fclose(outputFile);
     }
-    printf("Done\n");
 
     vtt_free(vtt);
 }

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -224,6 +224,6 @@ utf8_char_t* utf8_load_text_file(const char* path, size_t* size)
         }
     }
 
-    data[*size] = 0;
+    data[*size] = '\0';
     return data;
 }

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -227,3 +227,23 @@ utf8_char_t* utf8_load_text_file(const char* path, size_t* size)
     data[*size] = '\0';
     return data;
 }
+
+#ifndef strnstr
+char *strnstr(const char *string1, const char *string2, size_t len)
+{
+	size_t length2;
+
+    length2 = strlen(string2);
+	if (!length2) {
+        return (char *)string1;
+    }
+
+	while (len >= length2) {
+		len--;
+		if (!memcmp(string1, string2, length2))
+			return (char *)string1;
+		string1++;
+	}
+	return NULL;
+}
+#endif

--- a/src/vtt.c
+++ b/src/vtt.c
@@ -194,21 +194,17 @@ void parse_timestamps(const utf8_char_t* line, double *start_pts, double *end_pt
     *start_pts = -1;
     *cue_settings = NULL;
 
-    fprintf(stderr, "Matches: %d\n", matches);
     if (matches >= 1) {
         *start_pts = parse_timestamp(start_str);
-        fprintf(stderr, "Start pts: %lf\n", *start_pts);
     }
     if (matches >= 2) {
         *end_pts = parse_timestamp(end_str);
-        fprintf(stderr, "End pts: %lf\n", *end_pts);
     }
     if ((matches == 3) && (strlen(cue_str) > 0)) {
         int cue_size = strlen(cue_str);
-        fprintf(stderr, "Cues: %d %s\n", cue_size, *cue_settings);
         *cue_settings = malloc(cue_size + 1);
         strncpy(*cue_settings, cue_str, cue_size);
-        *cue_settings[cue_size] = '\0';
+        (*cue_settings)[cue_size] = '\0';
     }
 }
 

--- a/src/vtt.c
+++ b/src/vtt.c
@@ -1,0 +1,240 @@
+/**********************************************************************************************/
+/* The MIT License                                                                            */
+/*                                                                                            */
+/* Copyright 2016-2017 Twitch Interactive, Inc. or its affiliates. All Rights Reserved.       */
+/*                                                                                            */
+/* Permission is hereby granted, free of charge, to any person obtaining a copy               */
+/* of this software and associated documentation files (the "Software"), to deal              */
+/* in the Software without restriction, including without limitation the rights               */
+/* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell                  */
+/* copies of the Software, and to permit persons to whom the Software is                      */
+/* furnished to do so, subject to the following conditions:                                   */
+/*                                                                                            */
+/* The above copyright notice and this permission notice shall be included in                 */
+/* all copies or substantial portions of the Software.                                        */
+/*                                                                                            */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR                 */
+/* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                   */
+/* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                */
+/* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                     */
+/* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,              */
+/* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                  */
+/* THE SOFTWARE.                                                                              */
+/**********************************************************************************************/
+#include "vtt.h"
+#include "utf8.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+vtt_t* vtt_new(const utf8_char_t* data, size_t size, double timestamp, vtt_t* prev, vtt_t** head)
+{
+    vtt_t* vtt = malloc(sizeof(vtt_t) + size + 1);
+    vtt->next = 0;
+    vtt->duration = 0;
+    vtt->aloc = size;
+    vtt->timestamp = timestamp;
+    utf8_char_t* dest = (utf8_char_t*)vtt_data(vtt);
+
+    if (prev) {
+        prev->next = vtt;
+
+        if (0 >= prev->duration) {
+            prev->duration = timestamp - prev->timestamp;
+        }
+    }
+
+    if (head && 0 == (*head)) {
+        (*head) = vtt;
+    }
+
+    if (data) {
+        memcpy(dest, data, size);
+    } else {
+        memset(dest, 0, size);
+    }
+
+    dest[size] = '\0';
+    return vtt;
+}
+
+vtt_t* vtt_free_head(vtt_t* head)
+{
+    vtt_t* next = head->next;
+    if (head->cue_settings != NULL) {
+        free(head->cue_settings);
+    }
+    free(head);
+    return next;
+}
+
+void vtt_free(vtt_t* vtt)
+{
+    while (vtt) {
+        vtt = vtt_free_head(vtt);
+    }
+}
+
+#define VTTTIME2SECONDS(HH, MM, SS, MS) ((HH * 3600.0) + (MM * 60.0) + SS + (MS / 1000.0))
+double parse_timestamp(const utf8_char_t *line) {
+    int hh, mm, ss, ms;
+    if (sscanf(line, "%d:%2d:%2d.%3d", &hh, &mm, &ss, &ms) == 4) {
+        return VTTTIME2SECONDS(hh, mm, ss, ms);
+    }
+    if (sscanf(line, "%2d:%2d.%3d", &mm, &ss, &ms) == 3) {
+        return VTTTIME2SECONDS(0.0, mm, ss, ms);
+    }
+    return -1.0;
+}
+
+void parse_timestamps(const utf8_char_t* line, double *start_pts, double *end_pts, char **cues) {
+    char start_str[32];
+    char end_str[32];
+    char cue_str[1024];
+
+    int matches = sscanf(line, " %31s --> %31s%1023[^\n\r]", start_str, end_str, cue_str);
+    *start_pts = -1;
+    *cues = NULL;
+
+    fprintf(stderr, "Matches: %d\n", matches);
+    if (matches >= 1) {
+        *start_pts = parse_timestamp(start_str);
+        fprintf(stderr, "Start pts: %lf\n", *start_pts);
+    }
+    if (matches >= 2) {
+        *end_pts = parse_timestamp(end_str);
+        fprintf(stderr, "End pts: %lf\n", *end_pts);
+    }
+    if ((matches == 3) && (strlen(cue_str) > 0)) {
+        int cue_size = strlen(cue_str);
+        fprintf(stderr, "Cues: %d %s\n", cue_size, *cues);
+        *cues = malloc(cue_size + 1);
+        strncpy(*cues, cue_str, cue_size);
+        *cues[cue_size] = '\0';
+    }
+}
+
+vtt_t* vtt_parse(const utf8_char_t* data, size_t size)
+{
+    int counter;
+    vtt_t *head = 0, *prev = 0;
+    double str_pts = 0, end_pts = 0;
+    size_t line_length = 0, trimmed_length = 0;
+    char *cue_settings;
+
+    if (!data || !size || size < 6) {
+        return NULL;
+    }
+
+    if (strncmp(data, "WEBVTT", 6) != 0) {
+        // WebVTT files must start with WEBVTT
+        printf("Invalid webvtt header: %.*s\n", 6, data);
+        return NULL;
+    }
+
+    data += 6;
+    size -= 6;
+
+    for (;;) {
+        line_length = 0;
+
+        do {
+            data += line_length;
+            size -= line_length;
+            line_length = utf8_line_length(data);
+            trimmed_length = utf8_trimmed_length(data, line_length);
+            // Skip empty lines
+        } while (0 < line_length && 0 == trimmed_length);
+
+        // linelength cant be zero before EOF
+        if (0 == line_length) {
+            break;
+        }
+
+        if (strnstr(data, "-->", line_length) != NULL) {
+            fprintf(stderr, "Parse timestamps\n");
+            parse_timestamps(data, &str_pts, &end_pts, &cue_settings);
+            if (str_pts == -1) {
+                // Failed to parse timestamps
+                printf("Bad timestamp\n");
+                return NULL;
+            }
+        } else {
+            // Expected timestamp
+            printf("Expected timestamp\n");
+            return NULL;
+        }
+        
+        data += line_length;
+        size -= line_length;
+
+        // Caption text starts here
+        const utf8_char_t* text = data;
+        size_t text_size = 0;
+
+        line_length = 0;
+
+        do {
+            text_size += line_length;
+            line_length = utf8_line_length(data);
+            trimmed_length = utf8_trimmed_length(data, line_length);
+            // printf ("cap (%d): '%.*s'\n", line_length, (int) trimmed_length, data);
+            data += line_length;
+            size -= line_length;
+        } while (trimmed_length);
+
+        // should we trim here?
+        vtt_t* vtt = vtt_new(text, text_size, str_pts, prev, &head);
+        prev = vtt;
+        vtt->duration = end_pts - str_pts;
+        vtt->cue_settings = cue_settings;
+    }
+
+    return head;
+}
+
+int vtt_to_caption_frame(vtt_t* vtt, caption_frame_t* frame)
+{
+    const char* data = vtt_data(vtt);
+    return caption_frame_from_text(frame, data);
+}
+
+vtt_t* vtt_from_caption_frame(caption_frame_t* frame, vtt_t* prev, vtt_t** head)
+{
+    // CRLF per row, plus an extra at the end
+    vtt_t* vtt = vtt_new(NULL, 2 + CAPTION_FRAME_TEXT_BYTES, frame->timestamp, prev, head);
+    utf8_char_t* data = vtt_data(vtt);
+
+    caption_frame_to_text(frame, data);
+    // vtt requires an extra new line
+    strcat((char*)data, "\r\n");
+
+    return vtt;
+}
+
+static inline void _crack_time(double tt, int* hh, int* mm, int* ss, int* ms)
+{
+    (*ms) = (int)((int64_t)(tt * 1000) % 1000);
+    (*ss) = (int)((int64_t)(tt) % 60);
+    (*mm) = (int)((int64_t)(tt / (60)) % 60);
+    (*hh) = (int)((int64_t)(tt / (60 * 60)));
+}
+
+static void _dump(vtt_t* head)
+{
+    int i;
+    vtt_t* vtt;
+
+    printf("WEBVTT\r\n");
+
+    for (vtt = head, i = 1; vtt; vtt = vtt_next(vtt), ++i) {
+        int hh1, hh2, mm1, mm2, ss1, ss2, ms1, ms2;
+        _crack_time(vtt->timestamp, &hh1, &mm1, &ss1, &ms1);
+        _crack_time(vtt->timestamp + vtt->duration, &hh2, &mm2, &ss2, &ms2);
+
+        printf("%d:%02d:%02d.%03d --> %02d:%02d:%02d.%03d\r\n%s\r\n",
+            hh1, mm1, ss1, ms1, hh2, mm2, ss2, ms2, vtt_data(vtt));
+    }
+}
+
+void vtt_dump(vtt_t* head) { _dump(head); }

--- a/src/vtt.c
+++ b/src/vtt.c
@@ -27,27 +27,128 @@
 #include <stdlib.h>
 #include <string.h>
 
-vtt_t* vtt_new(const utf8_char_t* data, size_t size, double timestamp, vtt_t* prev, vtt_t** head)
+vtt_t *vtt_new() {
+    vtt_t *vtt = malloc(sizeof(vtt_t));
+    vtt->region_head = NULL;
+    vtt->style_head = NULL;
+    vtt->cue_head = NULL;
+    return vtt;
+}
+
+void vtt_free(vtt_t* vtt)
 {
-    vtt_t* vtt = malloc(sizeof(vtt_t) + size + 1);
-    vtt->next = 0;
-    vtt->duration = 0;
-    vtt->aloc = size;
-    vtt->timestamp = timestamp;
-    utf8_char_t* dest = (utf8_char_t*)vtt_data(vtt);
+    while (vtt->region_head != NULL) {
+        vtt->region_head = vtt_region_free_head(vtt->region_head);
+    }
+    while (vtt->style_head != NULL) {
+        vtt->style_head = vtt_style_free_head(vtt->style_head);
+    }
+    while (vtt->cue_head != NULL) {
+        vtt->cue_head = vtt_cue_free_head(vtt->cue_head);
+    }
+    free(vtt);
+}
 
-    if (prev) {
-        prev->next = vtt;
+vtt_region_t *vtt_region_new(vtt_t* vtt, const utf8_char_t* data, size_t size)
+{
+    vtt_region_t* region = malloc(sizeof(vtt_region_t) + size + 1);
+    region->next = NULL;
+    region->id_size = 0;
+    region->region_id = NULL;
+    region->block_size = size;
+    
+    if (vtt->region_head == NULL) {
+        vtt->region_head = region;        
+    } else {
+        vtt->region_tail->next = region;
+    }
+    vtt->region_tail = region;
 
-        if (0 >= prev->duration) {
-            prev->duration = timestamp - prev->timestamp;
-        }
+    utf8_char_t* dest = (utf8_char_t*)vtt_region_data(region);
+    if (data) {
+        memcpy(dest, data, size);
+    } else {
+        memset(dest, 0, size);
+    }
+    dest[size] = '\0';
+
+    return region;
+}
+
+void vtt_region_set_id(vtt_region_t* region, const utf8_char_t* data, size_t size)
+{
+    if (region->region_id != NULL) {
+        free(region->region_id);
     }
 
-    if (head && 0 == (*head)) {
-        (*head) = vtt;
+    region->id_size = size;
+    region->region_id = malloc(size + 1);
+    if (data) {
+        memcpy(region->region_id, data, size);
+    } else {
+        memset(region->region_id, 0, size);
     }
+    region->region_id[size] = '\0';
+}
 
+vtt_region_t* vtt_region_free_head(vtt_region_t* region)
+{
+    vtt_region_t* next = region->next;
+    if (region->region_id != NULL) {
+        free(region->region_id);
+    }
+    free(region);
+    return next;
+}
+
+vtt_style_t *vtt_style_new(vtt_t* vtt, const utf8_char_t* data, size_t size)
+{
+    vtt_style_t* style = malloc(sizeof(vtt_style_t) + size + 1);
+    style->next = NULL;
+    if (vtt->style_head == NULL) {
+        vtt->style_head = style;
+    } else {
+        vtt->style_tail->next = style;
+    }
+    vtt->style_tail = style;
+
+    utf8_char_t* dest = (utf8_char_t*)vtt_style_data(style);
+    if (data) {
+        memcpy(dest, data, size);
+    } else {
+        memset(dest, 0, size);
+    }
+    dest[size] = '\0';
+
+    return style;
+}
+
+vtt_style_t* vtt_style_free_head(vtt_style_t* style)
+{
+    vtt_style_t* next = style->next;
+    free(style);
+    return next;
+}
+
+vtt_cue_t* vtt_cue_new(vtt_t* vtt, const utf8_char_t* data, size_t size)
+{
+    vtt_cue_t* cue = malloc(sizeof(vtt_cue_t) + size + 1);
+    cue->next = NULL;
+    cue->timestamp = 0.0;
+    cue->duration = 0.0;
+    cue->cue_settings = NULL;
+    cue->cue_id = NULL;
+    cue->region = NULL;
+    cue->text_size = size;
+
+    if (vtt->cue_head == NULL) {
+        vtt->cue_head = cue;
+    } else {
+        vtt->cue_tail->next = cue;
+    }
+    vtt->cue_tail = cue;
+
+    utf8_char_t* dest = (utf8_char_t*)vtt_cue_data(cue);    
     if (data) {
         memcpy(dest, data, size);
     } else {
@@ -55,12 +156,15 @@ vtt_t* vtt_new(const utf8_char_t* data, size_t size, double timestamp, vtt_t* pr
     }
 
     dest[size] = '\0';
-    return vtt;
+    return cue;
 }
 
-vtt_t* vtt_free_head(vtt_t* head)
+vtt_cue_t* vtt_cue_free_head(vtt_cue_t* head)
 {
-    vtt_t* next = head->next;
+    vtt_cue_t* next = head->next;
+    if (head->cue_id != NULL) {
+        free(head->cue_id);
+    }
     if (head->cue_settings != NULL) {
         free(head->cue_settings);
     }
@@ -68,12 +172,6 @@ vtt_t* vtt_free_head(vtt_t* head)
     return next;
 }
 
-void vtt_free(vtt_t* vtt)
-{
-    while (vtt) {
-        vtt = vtt_free_head(vtt);
-    }
-}
 
 #define VTTTIME2SECONDS(HH, MM, SS, MS) ((HH * 3600.0) + (MM * 60.0) + SS + (MS / 1000.0))
 double parse_timestamp(const utf8_char_t *line) {
@@ -87,14 +185,14 @@ double parse_timestamp(const utf8_char_t *line) {
     return -1.0;
 }
 
-void parse_timestamps(const utf8_char_t* line, double *start_pts, double *end_pts, char **cues) {
+void parse_timestamps(const utf8_char_t* line, double *start_pts, double *end_pts, char **cue_settings) {
     char start_str[32];
     char end_str[32];
     char cue_str[1024];
 
     int matches = sscanf(line, " %31s --> %31s%1023[^\n\r]", start_str, end_str, cue_str);
     *start_pts = -1;
-    *cues = NULL;
+    *cue_settings = NULL;
 
     fprintf(stderr, "Matches: %d\n", matches);
     if (matches >= 1) {
@@ -107,33 +205,38 @@ void parse_timestamps(const utf8_char_t* line, double *start_pts, double *end_pt
     }
     if ((matches == 3) && (strlen(cue_str) > 0)) {
         int cue_size = strlen(cue_str);
-        fprintf(stderr, "Cues: %d %s\n", cue_size, *cues);
-        *cues = malloc(cue_size + 1);
-        strncpy(*cues, cue_str, cue_size);
-        *cues[cue_size] = '\0';
+        fprintf(stderr, "Cues: %d %s\n", cue_size, *cue_settings);
+        *cue_settings = malloc(cue_size + 1);
+        strncpy(*cue_settings, cue_str, cue_size);
+        *cue_settings[cue_size] = '\0';
     }
 }
 
 vtt_t* vtt_parse(const utf8_char_t* data, size_t size)
 {
-    int counter;
-    vtt_t *head = 0, *prev = 0;
+    vtt_t *vtt = NULL;
     double str_pts = 0, end_pts = 0;
     size_t line_length = 0, trimmed_length = 0;
     char *cue_settings;
+    enum VTT_BLOCK_TYPE block_type;
+    size_t cue_id_length = 0;
+    const utf8_char_t* cue_id = NULL;
 
     if (!data || !size || size < 6) {
         return NULL;
     }
 
+    // TODO: Support UTF-8 BOM?
     if (strncmp(data, "WEBVTT", 6) != 0) {
         // WebVTT files must start with WEBVTT
-        printf("Invalid webvtt header: %.*s\n", 6, data);
+        fprintf(stderr, "Invalid webvtt header: %.*s\n", 6, data);
         return NULL;
     }
 
     data += 6;
     size -= 6;
+
+    vtt = vtt_new();
 
     for (;;) {
         line_length = 0;
@@ -141,30 +244,45 @@ vtt_t* vtt_parse(const utf8_char_t* data, size_t size)
         do {
             data += line_length;
             size -= line_length;
-            line_length = utf8_line_length(data);
+            line_length = utf8_line_length(data); // Line length 
             trimmed_length = utf8_trimmed_length(data, line_length);
             // Skip empty lines
         } while (0 < line_length && 0 == trimmed_length);
 
-        // linelength cant be zero before EOF
+        // line length only zero at EOF
         if (0 == line_length) {
             break;
         }
 
-        if (strnstr(data, "-->", line_length) != NULL) {
-            fprintf(stderr, "Parse timestamps\n");
+        if (strnstr(data, "REGION", line_length) != NULL) {
+            block_type = VTT_REGION;
+        } else if (strnstr(data, "STYLE", line_length) != NULL) {
+            block_type = VTT_STYLE;
+        } else if (strnstr(data, "NOTE", line_length) != NULL) {
+            block_type = VTT_NOTE;
+        } else if (strnstr(data, "-->", line_length) != NULL) {
+            block_type = VTT_CUE;
             parse_timestamps(data, &str_pts, &end_pts, &cue_settings);
             if (str_pts == -1) {
                 // Failed to parse timestamps
-                printf("Bad timestamp\n");
+                fprintf(stderr, "Bad timestamp\n");
                 return NULL;
             }
         } else {
-            // Expected timestamp
-            printf("Expected timestamp\n");
-            return NULL;
+            if (cue_id != NULL) {
+                // Invalid text found
+                fprintf(stderr, "ERR: Unrecognized block\n");
+                return NULL;
+            }
+
+            cue_id = data;
+            cue_id_length = line_length;
+
+            data += line_length;
+            size -= line_length;
+            continue;
         }
-        
+
         data += line_length;
         size -= line_length;
 
@@ -184,32 +302,55 @@ vtt_t* vtt_parse(const utf8_char_t* data, size_t size)
         } while (trimmed_length);
 
         // should we trim here?
-        vtt_t* vtt = vtt_new(text, text_size, str_pts, prev, &head);
-        prev = vtt;
-        vtt->duration = end_pts - str_pts;
-        vtt->cue_settings = cue_settings;
+        // TODO: Add a notion of VTT type here (region, note, etc.)
+        switch (block_type) {
+            case VTT_REGION:
+                vtt_region_new(vtt, text, text_size);
+                // TODO: Set the region ID
+                break;
+            case VTT_STYLE:
+                vtt_style_new(vtt, text, text_size);
+                break;
+            case VTT_CUE:
+            {
+                vtt_cue_t* cue = vtt_cue_new(vtt, text, text_size);
+                cue->timestamp = str_pts;
+                cue->duration = end_pts - str_pts;
+                cue->cue_settings = cue_settings;
+                if (cue_id != NULL) {
+                    cue->cue_id = malloc(cue_id_length + 1);
+                    memcpy(cue->cue_id, cue_id, cue_id_length);
+                    cue->cue_id[cue_id_length] = '\0';
+                }
+            }
+                break;
+            case VTT_NOTE:
+                break;
+        }
+
+        cue_id = NULL;
     }
 
-    return head;
+    return vtt;
 }
 
-int vtt_to_caption_frame(vtt_t* vtt, caption_frame_t* frame)
+int vtt_cue_to_caption_frame(vtt_cue_t* cue, caption_frame_t* frame)
 {
-    const char* data = vtt_data(vtt);
+    const char* data = vtt_cue_data(cue);
     return caption_frame_from_text(frame, data);
 }
 
-vtt_t* vtt_from_caption_frame(caption_frame_t* frame, vtt_t* prev, vtt_t** head)
+vtt_cue_t* vtt_cue_from_caption_frame(caption_frame_t* frame, vtt_t *vtt)
 {
     // CRLF per row, plus an extra at the end
-    vtt_t* vtt = vtt_new(NULL, 2 + CAPTION_FRAME_TEXT_BYTES, frame->timestamp, prev, head);
-    utf8_char_t* data = vtt_data(vtt);
+    vtt_cue_t* cue = vtt_cue_new(vtt, NULL, 2 + CAPTION_FRAME_TEXT_BYTES);
+    utf8_char_t* data = vtt_cue_data(cue);
 
     caption_frame_to_text(frame, data);
     // vtt requires an extra new line
     strcat((char*)data, "\r\n");
 
-    return vtt;
+    return cue;
 }
 
 static inline void _crack_time(double tt, int* hh, int* mm, int* ss, int* ms)
@@ -220,20 +361,33 @@ static inline void _crack_time(double tt, int* hh, int* mm, int* ss, int* ms)
     (*hh) = (int)((int64_t)(tt / (60 * 60)));
 }
 
-static void _dump(vtt_t* head)
+static void _dump(vtt_t* vtt)
 {
-    int i;
-    vtt_t* vtt;
-
+    vtt_region_t* region;
+    vtt_style_t* style;
+    vtt_cue_t* cue;
     printf("WEBVTT\r\n");
 
-    for (vtt = head, i = 1; vtt; vtt = vtt_next(vtt), ++i) {
+    region = vtt->region_head;
+    while (region != NULL) {
+        printf("REGION\r\n%s\r\n", vtt_region_data(region));
+        region = region->next;
+    }
+
+    style = vtt->style_head;
+    while (style != NULL) {
+        printf("STYLE\r\n%s\r\n", vtt_style_data(style));
+        style = style->next;
+    }
+
+    cue = vtt->cue_head;
+    while (cue != NULL) {
         int hh1, hh2, mm1, mm2, ss1, ss2, ms1, ms2;
-        _crack_time(vtt->timestamp, &hh1, &mm1, &ss1, &ms1);
-        _crack_time(vtt->timestamp + vtt->duration, &hh2, &mm2, &ss2, &ms2);
+        _crack_time(cue->timestamp, &hh1, &mm1, &ss1, &ms1);
+        _crack_time(cue->timestamp + cue->duration, &hh2, &mm2, &ss2, &ms2);
 
         printf("%d:%02d:%02d.%03d --> %02d:%02d:%02d.%03d\r\n%s\r\n",
-            hh1, mm1, ss1, ms1, hh2, mm2, ss2, ms2, vtt_data(vtt));
+            hh1, mm1, ss1, ms1, hh2, mm2, ss2, ms2, vtt_cue_data(cue));
     }
 }
 

--- a/unit_tests/sample_files/example1.vtt
+++ b/unit_tests/sample_files/example1.vtt
@@ -1,0 +1,41 @@
+WEBVTT
+
+00:11.000 --> 00:13.000
+<v Roger Bingham>We are in New York City
+
+00:13.000 --> 00:16.000
+<v Roger Bingham>We’re actually at the Lucern Hotel, just down the street
+
+00:16.000 --> 00:18.000
+<v Roger Bingham>from the American Museum of Natural History
+
+00:18.000 --> 00:20.000
+<v Roger Bingham>And with me is Neil deGrasse Tyson
+
+00:20.000 --> 00:22.000
+<v Roger Bingham>Astrophysicist, Director of the Hayden Planetarium
+
+00:22.000 --> 00:24.000
+<v Roger Bingham>at the AMNH.
+
+00:24.000 --> 00:26.000
+<v Roger Bingham>Thank you for walking down here.
+
+00:27.000 --> 00:30.000
+<v Roger Bingham>And I want to do a follow-up on the last conversation we did.
+
+00:30.000 --> 00:31.500 align:right size:50%
+<v Roger Bingham>When we e-mailed—
+
+00:30.500 --> 00:32.500 align:left size:50%
+<v Neil deGrasse Tyson>Didn’t we talk about enough in that conversation?
+
+00:32.000 --> 00:35.500 align:right size:50%
+<v Roger Bingham>No! No no no no; 'cos 'cos obviously 'cos
+
+00:32.500 --> 00:33.500 align:left size:50%
+<v Neil deGrasse Tyson><i>Laughs</i>
+
+00:35.500 --> 00:38.000
+<v Roger Bingham>You know I’m so excited my glasses are falling off here.
+

--- a/unit_tests/sample_files/example2.vtt
+++ b/unit_tests/sample_files/example2.vtt
@@ -1,0 +1,12 @@
+WEBVTT
+
+00:01.000 --> 00:04.000
+Never drink liquid nitrogen.
+
+00:05.000 --> 00:09.000
+— It will perforate your stomach.
+— You could die.
+
+00:10.000 --> 00:14.000
+The Organisation for Sample Public Service Announcements accepts no liability for the content of this advertisement, or for the consequences of any actions taken on the basis of the information provided.
+

--- a/unit_tests/sample_files/example3.vtt
+++ b/unit_tests/sample_files/example3.vtt
@@ -1,0 +1,22 @@
+WEBVTT
+
+NOTE
+This file was written by Jill. I hope
+you enjoy reading it. Some things to
+bear in mind:
+- I was lip-reading, so the cues may
+not be 100% accurate
+- I didn’t pay too close attention to
+when the cues should start or end.
+
+00:01.000 --> 00:04.000
+Never drink liquid nitrogen.
+
+NOTE check next cue
+
+00:05.000 --> 00:09.000
+— It will perforate your stomach.
+— You could die.
+
+NOTE end of file
+

--- a/unit_tests/sample_files/example4.vtt
+++ b/unit_tests/sample_files/example4.vtt
@@ -1,0 +1,22 @@
+WEBVTT
+
+STYLE
+::cue {
+  background-image: linear-gradient(to bottom, dimgray, lightgray);
+  color: papayawhip;
+}
+/* Style blocks cannot use blank lines nor "dash dash greater than" */
+
+NOTE comment blocks can be used between style blocks.
+
+STYLE
+::cue(b) {
+  color: peachpuff;
+}
+
+hello
+00:00:00.000 --> 00:00:10.000
+Hello <b>world</b>.
+
+NOTE style blocks cannot appear after the first cue.
+

--- a/unit_tests/sample_files/example5.vtt
+++ b/unit_tests/sample_files/example5.vtt
@@ -1,0 +1,14 @@
+WEBVTT
+
+test
+00:00.000 --> 00:02.000
+This is a test.
+
+123
+00:00.000 --> 00:02.000
+That’s an, an, that’s an L!
+
+crédit de transcription
+00:04.000 --> 00:05.000
+Transcrit par Célestes™
+

--- a/unit_tests/sample_files/example6.vtt
+++ b/unit_tests/sample_files/example6.vtt
@@ -1,0 +1,36 @@
+WEBVTT
+
+REGION
+id:fred
+width:40%
+lines:3
+regionanchor:0%,100%
+viewportanchor:10%,90%
+scroll:up
+
+REGION
+id:bill
+width:40%
+lines:3
+regionanchor:100%,100%
+viewportanchor:90%,90%
+scroll:up
+
+00:00:00.000 --> 00:00:20.000 region:fred align:left
+<v Fred>Hi, my name is Fred
+
+00:00:02.500 --> 00:00:22.500 region:bill align:right
+<v Bill>Hi, I’m Bill
+
+00:00:05.000 --> 00:00:25.000 region:fred align:left
+<v Fred>Would you like to get a coffee?
+
+00:00:07.500 --> 00:00:27.500 region:bill align:right
+<v Bill>Sure! I’ve only had one today.
+
+00:00:10.000 --> 00:00:30.000 region:fred align:left
+<v Fred>This is my fourth!
+
+00:00:12.500 --> 00:00:32.500 region:fred align:left
+<v Fred>OK, let’s go.
+


### PR DESCRIPTION
This PR adds first-class support for VTT to libcaption.

It adds `vtt.c` and `vtt.h`, which together mimic the previous SRT functionality for VTT files. This also supports parsing REGION, STYLE, and NOTE blocks, although currently NOTE blocks are simply discarded.

VTT is a superset of SRT, with the addition of a `WEBVTT` header.  As such, this new VTT functionality replaces all the old SRT code with VTT code, and defines helper functions and types that make working with SRT easy.

Since VTT files contain REGION, STYLE and CUE blocks independently, I've made a new struct `vtt_t` which contains pointers to the linked lists for each of these block types.

I've also added a new example, `vttsegmenter`, which allows for the creation of a segmented VTT file set useful for creating m3u8 files with segmented subtitles. The vtt segmenter makes use of the differences between blocks - in order to segment a WebVTT file, the STYLE and REGION blocks must be preserved and replicated across every segment, but only the CUEs for the given time range need to be present.