### PR TITLE
Update vtt.c cue_settings uninitialized variable

### DIFF
--- a/src/vtt.c
+++ b/src/vtt.c
@@ -188,7 +188,7 @@ vtt_t* _vtt_parse(const utf8_char_t* data, size_t size, int srt_mode)
     vtt_t* vtt = NULL;
     double str_pts = 0, end_pts = 0;
     size_t line_length = 0, trimmed_length = 0;
-    char* cue_settings;
+    char* cue_settings = NULL;
     enum VTT_BLOCK_TYPE block_type;
     size_t cue_id_length = 0;
     const utf8_char_t* cue_id = NULL;


### PR DESCRIPTION
Error    C4703    potentially uninitialized local pointer variable 'cue_settings' used ... libcaption\src\vtt.c    278  

Microsoft UWP compiler complains about it even though all code paths seem to initialize it. `parse_timestamps` always fill it: https://github.com/szatmary/libcaption/pull/52/files#diff-61993fbd8c570847e446e6264b8fc485R236

And when that is called, `block_type` is set `VTT_CUE` which is the only path that uses it afterward:
https://github.com/szatmary/libcaption/pull/52/files#diff-61993fbd8c570847e446e6264b8fc485R282
