### PR TITLE
C89 compile

### DIFF
--- a/caption/eia608.h
+++ b/caption/eia608.h
@@ -166,6 +166,40 @@ typedef enum {
     eia608_control_end_of_caption = 0x142F,
 } eia608_control_t;
 
+
+
+typedef enum {
+ eia608_status_unhandled,
+ eia608_status_unknown_control,
+ eia608_status_control,
+ eia608_status_preamble,
+ eia608_status_pad,
+ eia608_status_parity_failed,
+ eia608_status_basicna,
+ eia608_status_specialna,
+ eia608_status_westeu,
+ eia608_status_norpak,
+ eia608_status_xds,
+ eia608_status_midrowchange
+
+} eia608_status_t;
+
+
+typedef struct eia608_parsed{
+	eia608_status_t status;
+	eia608_control_t control;
+    eia608_style_t style;
+    int row;
+    int col;
+    int chan;
+    int underline;
+    char char1[5];
+    char char2[5];
+    uint8_t has_text;
+
+} eia608_parsed_t;
+
+
 /*! \brief
     \param
 */
@@ -201,6 +235,9 @@ int eia608_to_utf8(uint16_t c, int* chan, utf8_char_t* char1, utf8_char_t* char2
     \param
 */
 void eia608_dump(uint16_t cc_data);
+
+void eia608_parse_data(uint16_t cc_data, eia608_parsed_t *parsed);
+
 ////////////////////////////////////////////////////////////////////////////////
 #ifdef __cplusplus
 }

--- a/caption/eia608_from_utf8.h
+++ b/caption/eia608_from_utf8.h
@@ -1,0 +1,35 @@
+/**********************************************************************************************/
+/* The MIT License                                                                            */
+/*                                                                                            */
+/* Copyright 2016-2017 Twitch Interactive, Inc. or its affiliates. All Rights Reserved.       */
+/*                                                                                            */
+/* Permission is hereby granted, free of charge, to any person obtaining a copy               */
+/* of this software and associated documentation files (the "Software"), to deal              */
+/* in the Software without restriction, including without limitation the rights               */
+/* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell                  */
+/* copies of the Software, and to permit persons to whom the Software is                      */
+/* furnished to do so, subject to the following conditions:                                   */
+/*                                                                                            */
+/* The above copyright notice and this permission notice shall be included in                 */
+/* all copies or substantial portions of the Software.                                        */
+/*                                                                                            */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR                 */
+/* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,                   */
+/* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE                */
+/* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER                     */
+/* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,              */
+/* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN                  */
+/* THE SOFTWARE.                                                                              */
+/**********************************************************************************************/
+#ifndef LIBCAPTION_EIA608_FROM_UTF8_H
+#define LIBCAPTION_EIA608_FROM_UTF8_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint16_t _eia608_from_utf8 (const utf8_char_t* s);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/eia608.c
+++ b/src/eia608.c
@@ -197,9 +197,9 @@ void eia608_dump(uint16_t cc_data)
     eia608_style_t style;
     const char* text = 0;
     char char1[5], char2[5];
-    char1[0] = char2[0] = 0;
     int row, col, chan, underline;
 
+    char1[0] = char2[0] = 0;
     if (!eia608_parity_varify(cc_data)) {
         text = "parity failed";
     } else if (0 == eia608_parity_strip(cc_data)) {

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -36,14 +36,14 @@ const utf8_char_t* utf8_char_next(const utf8_char_t* c)
 // returnes the length of the char in bytes
 size_t utf8_char_length(const utf8_char_t* c)
 {
-    // count null term as zero size
-    if (!c || 0x00 == c[0]) {
-        return 0;
-    }
-
     static const size_t _utf8_char_length[] = {
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 3, 3, 4, 0
     };
+
+	// count null term as zero size
+    if (!c || 0x00 == c[0]) {
+        return 0;
+    }
 
     return _utf8_char_length[(c[0] >> 3) & 0x1F];
 }
@@ -120,8 +120,9 @@ utf8_size_t utf8_char_count(const char* data, size_t size)
 // returns the length of the line in bytes triming not printable charcters at the end
 size_t utf8_trimmed_length(const utf8_char_t* data, utf8_size_t charcters)
 {
-    size_t l, t = 0, split_at = 0;
-    for (size_t c = 0; (*data) && c < charcters; ++c) {
+    size_t l, t = 0, split_at = 0, c = 0;
+
+    for (c = 0; (*data) && c < charcters; ++c) {
         l = utf8_char_length(data);
         if (!utf8_char_whitespace(data)) {
             split_at = t + l;
@@ -132,7 +133,7 @@ size_t utf8_trimmed_length(const utf8_char_t* data, utf8_size_t charcters)
     return split_at;
 }
 
-size_t _utf8_newline(const utf8_char_t* data)
+static size_t _utf8_newline(const utf8_char_t* data)
 {
     if ('\r' == data[0]) {
         return '\n' == data[1] ? 2 : 1; // windows/unix
@@ -199,8 +200,10 @@ utf8_char_t* utf8_load_text_file(const char* path, size_t* size)
     FILE* file = fopen(path, "r");
 
     if (file) {
+    	size_t file_size = 0;
+
         fseek(file, 0, SEEK_END);
-        size_t file_size = ftell(file);
+        file_size = ftell(file);
         fseek(file, 0, SEEK_SET);
 
         if (0 == (*size) || file_size <= (*size)) {


### PR DESCRIPTION
Hello !
This PR makes a few small changes to comply with C89 standard. It also adds a parser,
based on eia608_dump, that parses a pair of 608 bytes and returns control code or text.