### PR TITLE
Replace bitfields in caption_frame_cell_t and caption_frame_state_t s…

### DIFF
--- a/caption/caption.h
+++ b/caption/caption.h
@@ -55,8 +55,8 @@ static inline libcaption_stauts_t libcaption_status_update(libcaption_stauts_t o
 #define SCREEN_COLS 32
 
 typedef struct {
-    unsigned int uln : 1; //< underline
-    unsigned int sty : 3; //< style
+    uint8_t uln;         //< underline
+    uint8_t sty;         //< style
     utf8_char_t data[5]; //< 4 byte utf8 values plus null term
 } caption_frame_cell_t;
 
@@ -65,9 +65,9 @@ typedef struct {
 } caption_frame_buffer_t;
 
 typedef struct {
-    unsigned int uln : 1; //< underline
-    unsigned int sty : 3; //< style
-    unsigned int rup : 2; //< roll-up line count minus 1
+    uint8_t uln; //< underline
+    uint8_t sty; //< style
+    uint8_t rup; //< roll-up line count minus 1
     int8_t row, col;
     uint16_t cc_data;
 } caption_frame_state_t;


### PR DESCRIPTION
…tructs with uint8_t

Contrary to what one might believe, this actually reduces the size of
the structs due to alignment constraints. On Linux x86-64 clang/gcc it
reduces the size of the caption_frame_t struct from 7760 bytes to 6800
bytes, on Windows x86-64 MSVC from 11600 bytes to 6800 bytes.

It also causes simpler and potentially faster assembly to be generated
as the values can be directly accessed as uint8_t instead of having to
extract the corresponding bits with bitwise operations.