### PR TITLE
Fix file pointer leak in utf8_load_text_file

### DIFF
--- a/src/utf8.c
+++ b/src/utf8.c
@@ -217,9 +217,9 @@ utf8_char_t* utf8_load_text_file(const char* path, size_t* size)
                     (*size) += bytes_read;
                 }
             }
-
-            fclose(file);
         }
+
+        fclose(file);
     }
 
     data[*size] = 0;


### PR DESCRIPTION
GCC's static analyzer found a file pointer leak. I moved `fclose` to the outside of an `if` closure so that the file pointer will be always released when the file was successfully opened.

Tested with gcc (GCC) 12.2.1 20221121 (Red Hat 12.2.1-4).
I configured with option `-fanalyzer -Wanalyzer-use-after-free -Wanalyzer-double-free -Wanalyzer-malloc-leak` and built the code.
